### PR TITLE
Issue #16 - memory access queue font color

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,10 @@ simulator.config(function($mdThemingProvider) {
             .primaryPalette('blue')
             .accentPalette('blue-grey')
             .dark();
+
+        $mdThemingProvider.theme('docs-light')
+            .primaryPalette('blue')
+            .accentPalette('blue-grey');
     });
 
 simulator.controller('IndexController', ['$scope', function($scope) {

--- a/src/cacheDisplay.html
+++ b/src/cacheDisplay.html
@@ -28,9 +28,9 @@
         <!--</div>-->
 
         <!--Mode code, but cache levels are different sizes-->
-        <div layout="inline">
+        <div ng-app="Simulator" ng-controller="IndexController" layout="inline">
             <!--L1-->
-            <md-card ng-show="showCache[0]" flex="40">
+            <md-card ng-show="showCache[0]" ng-click="$ctrl.clickCache(1)" flex="40">
                 <md-card-title layout="column">
                     <md-card-title-text>
                         <div layout="row" layout-align="space-between">
@@ -51,7 +51,7 @@
             </md-card>
 
             <!--L2-->
-            <md-card ng-show="showCache[1]" flex>
+            <md-card ng-show="showCache[1]" ng-click="$ctrl.clickCache(2)" flex>
                 <md-card-title layout="column">
                     <md-card-title-text>
                         <div layout="row" layout-align="space-between">
@@ -72,11 +72,11 @@
                 </md-card-title>
             </md-card>
         </div>
-        <div layout="column">
+        <div ng-controller="IndexController" layout="column">
             <!--L3-->
             <md-card ng-show="showCache[2]">
                 <md-card-title layout="column">
-                    <md-card-title-text>
+                    <md-card ng-show="showCache[2]" ng-click="$ctrl.clickCache(3)">
                         <div layout="row" layout-align="space-between">
                             <div>
                                 <span class="md-headline">{{$ctrl.caches[2].title}}</span>

--- a/src/cacheDisplay.html
+++ b/src/cacheDisplay.html
@@ -100,7 +100,7 @@
 
     <!--Cache Input-->
     <section resizable r-directions="['left']" r-flex="true" style="max-width: 700px">
-        <md-content layout="column" layout-padding md-theme="docs-dark" class="md-inline-form" flex>
+        <md-content layout="column" layout-padding md-theme="docs-light" class="md-inline-form" flex>
             <md-input-container>
                 <label>Replacement Policy</label>
                 <md-select ng-model="$ctrl.policy" placeholder="Select a Policy" ng-change="$ctrl.setPolicy()">

--- a/src/cacheDisplay.html
+++ b/src/cacheDisplay.html
@@ -28,9 +28,9 @@
         <!--</div>-->
 
         <!--Mode code, but cache levels are different sizes-->
-        <div ng-app="Simulator" ng-controller="IndexController" layout="inline">
+        <div layout="inline">
             <!--L1-->
-            <md-card ng-show="showCache[0]" ng-click="$ctrl.clickCache(1)" flex="40">
+            <md-card ng-show="showCache[0]" flex="40">
                 <md-card-title layout="column">
                     <md-card-title-text>
                         <div layout="row" layout-align="space-between">
@@ -47,12 +47,11 @@
                         <div class="md-media-lg card-media"></div>
                     </md-card-title-media>
                     <md-button ng-click="$ctrl.removeCache(0)" ng-disabled="$ctrl.disableDeleteCache"><i class="material-icons">delete</i></md-button>
-
                 </md-card-title>
             </md-card>
 
             <!--L2-->
-            <md-card ng-show="showCache[1]" ng-click="$ctrl.clickCache(2)" flex>
+            <md-card ng-show="showCache[1]" flex>
                 <md-card-title layout="column">
                     <md-card-title-text>
                         <div layout="row" layout-align="space-between">
@@ -72,11 +71,10 @@
                     <md-button ng-click="$ctrl.removeCache(1)"><i class="material-icons">delete</i></md-button>
                 </md-card-title>
             </md-card>
-
         </div>
-        <div ng-controller="IndexController" layout="column">
+        <div layout="column">
             <!--L3-->
-            <md-card ng-show="showCache[2]" ng-click="$ctrl.clickCache(3)">
+            <md-card ng-show="showCache[2]">
                 <md-card-title layout="column">
                     <md-card-title-text>
                         <div layout="row" layout-align="space-between">
@@ -157,6 +155,8 @@
                 <md-subheader class="md-no-sticky">{{$ctrl.fileName}}</md-subheader>
                 <md-button class="md-primary md-raised" ng-click="$ctrl.handleUpload()" ng-disabled="$ctrl.fileName.length != 0" type="submit" style="margin-right: 0;">Upload</md-button>
             </md-content>
+        </md-content>
+        <md-content layout="column" layout-padding class="md-inline-form" flex>
             <md-subheader class="md-no-sticky">Memory Access Queue</md-subheader>
             <md-table-container style="height:150px">
                 <table md-table>
@@ -178,7 +178,8 @@
                     </tbody>
                 </table>
             </md-table-container>
-
+        </md-content>
+        <md-content layout="column" layout-padding class="md-inline-form" md-theme="docs-dark" flex>
             <!-- Control Flow Buttons -->
             <md-content layout="row" layout-align="space-around center">
                 <md-button class="md-icon-button"><i class="material-icons">skip_previous</i></md-button>

--- a/src/cacheDisplay.html
+++ b/src/cacheDisplay.html
@@ -74,9 +74,9 @@
         </div>
         <div ng-controller="IndexController" layout="column">
             <!--L3-->
-            <md-card ng-show="showCache[2]">
+            <md-card ng-show="showCache[2]" ng-click="$ctrl.clickCache(3)">
                 <md-card-title layout="column">
-                    <md-card ng-show="showCache[2]" ng-click="$ctrl.clickCache(3)">
+                    <md-card-title-text>
                         <div layout="row" layout-align="space-between">
                             <div>
                                 <span class="md-headline">{{$ctrl.caches[2].title}}</span>

--- a/src/cacheDisplay.html
+++ b/src/cacheDisplay.html
@@ -47,6 +47,7 @@
                         <div class="md-media-lg card-media"></div>
                     </md-card-title-media>
                     <md-button ng-click="$ctrl.removeCache(0)" ng-disabled="$ctrl.disableDeleteCache"><i class="material-icons">delete</i></md-button>
+
                 </md-card-title>
             </md-card>
 
@@ -71,6 +72,7 @@
                     <md-button ng-click="$ctrl.removeCache(1)"><i class="material-icons">delete</i></md-button>
                 </md-card-title>
             </md-card>
+
         </div>
         <div ng-controller="IndexController" layout="column">
             <!--L3-->
@@ -155,8 +157,6 @@
                 <md-subheader class="md-no-sticky">{{$ctrl.fileName}}</md-subheader>
                 <md-button class="md-primary md-raised" ng-click="$ctrl.handleUpload()" ng-disabled="$ctrl.fileName.length != 0" type="submit" style="margin-right: 0;">Upload</md-button>
             </md-content>
-        </md-content>
-        <md-content layout="column" layout-padding class="md-inline-form" flex>
             <md-subheader class="md-no-sticky">Memory Access Queue</md-subheader>
             <md-table-container style="height:150px">
                 <table md-table>
@@ -178,8 +178,7 @@
                     </tbody>
                 </table>
             </md-table-container>
-        </md-content>
-        <md-content layout="column" layout-padding class="md-inline-form" md-theme="docs-dark" flex>
+
             <!-- Control Flow Buttons -->
             <md-content layout="row" layout-align="space-around center">
                 <md-button class="md-icon-button"><i class="material-icons">skip_previous</i></md-button>
@@ -193,7 +192,7 @@
                     <span class="md-body-1">Speed</span>
                 </div>
                 <div style="width:100%;padding:10px">
-                	<md-slider flex class="md-primary" md-discrete ng-model="$ctrl.speedRating" step="1" min="1" max="5" aria-label="rating">
+                    <md-slider flex class="md-primary" md-discrete ng-model="$ctrl.speedRating" step="1" min="1" max="5" aria-label="rating">
                 </div>
                 </md-slider>
             </md-content>


### PR DESCRIPTION
After having a lot of difficulties changing the font color on the md-data-table element and stumbling upon this issue:
https://github.com/daniel-nagy/md-data-table/issues/153
It turns out that this element doesn't play well with dark themes since the styling for the table is hardcoded into the CSS, apparently there is an open PR to fix this but it hasn't been merged yet:
https://github.com/daniel-nagy/md-data-table/pull/607

The current fix I've added on this PR changes just the memory access queue area to a light background, which fixes the issue but isn't the most attractive solution IMO:
![screen shot 2017-09-20 at 1 38 27 pm](https://user-images.githubusercontent.com/13342312/30658734-b45d029c-9e09-11e7-810c-88be2333c23d.png)

There is also another option (NOT in this PR) to change the entire sidebar to a light theme:
![screen shot 2017-09-20 at 1 39 25 pm](https://user-images.githubusercontent.com/13342312/30658778-d4821756-9e09-11e7-8012-80fd143d8135.png)

So we can decide amongst ourselves which of these two would be preferred for the time being.