### PR TITLE
Cache levels Dynamically scale in the UI and other slight changes

### DIFF
--- a/src/cacheDisplay.html
+++ b/src/cacheDisplay.html
@@ -31,10 +31,10 @@
             <!--</md-card>-->
         <!--</div>-->
 
-        <!--Mode code, but cache levels are different sizes-->
-        <div ng-app="Simulator" ng-controller="IndexController" layout="inline">
+        <!--More code, but cache levels are different sizes-->
+        <div ng-app="Simulator" ng-controller="IndexController" layout="row" flex>
             <!--L1-->
-            <md-card ng-show="showCache[0]" ng-click="$ctrl.clickCache(1)" flex="40">
+            <md-card ng-show="showCache[0]" ng-click="$ctrl.clickCache(1)" flex>
                 <md-card-title layout="column">
                     <md-card-title-text>
                         <div layout="row" layout-align="space-between">
@@ -54,9 +54,8 @@
 
                 </md-card-title>
             </md-card>
-
             <!--L2-->
-            <md-card ng-show="showCache[1]" ng-click="$ctrl.clickCache(2)" flex>
+            <md-card ng-show="showCache[1]" ng-click="$ctrl.clickCache(2)" flex="60">
                 <md-card-title layout="column">
                     <md-card-title-text>
                         <div layout="row" layout-align="space-between">
@@ -76,7 +75,6 @@
                     <md-button ng-click="$ctrl.removeCache(1, $event)"><i class="material-icons">delete</i></md-button>
                 </md-card-title>
             </md-card>
-
         </div>
         <div ng-controller="IndexController" layout="column">
             <!--L3-->
@@ -105,7 +103,7 @@
     <!--Cache Input-->
     <section resizable r-directions="['left']" r-flex="true" style="max-width: 700px">
         <md-content layout="column" layout-padding md-theme="docs-light" class="md-inline-form" flex>
-            <md-input-container>
+            <md-input-container ng-hide="$ctrl.hide">
                 <label>Replacement Policy</label>
                 <md-select ng-model="$ctrl.policy" placeholder="Select a Policy" ng-change="$ctrl.setPolicy()">
                     <md-option ng-repeat="policy in policies" value="{{policy}}">
@@ -114,7 +112,7 @@
                 </md-select>
             </md-input-container>
 
-            <md-input-container>
+            <md-input-container ng-hide="$ctrl.hide">
                 <label>Block Size</label>
                 <md-select ng-model="$ctrl.blockSize" ng-change="$ctrl.setBlockSize()" placeholder="Select a Block Size">
                     <md-option ng-repeat="size in blockSizes" value="{{size}}">
@@ -123,19 +121,19 @@
                 </md-select>
             </md-input-container>
 
-            <md-tabs md-selected="selectedIndex" md-border-bottom md-autoselect>
-                <md-tab ng-disabled="$ctrl.caches.length === 3">
+            <md-tabs md-selected="selectedIndex" md-border-bottom md-autoselect ng-hide="$ctrl.hide">
+                <md-tab ng-disabled="$ctrl.caches.length === 3" ng-hide="$ctrl.hide">
                     <md-tab-label class="add-button">
-                        <md-button class="md-icon-button" ng-click="$ctrl.addCache()"><i class="material-icons">add</i></md-button>
+                        <md-button class="md-icon-button" ng-click="$ctrl.addCache()" ng-hide="$ctrl.hide"><i class="material-icons">add</i></md-button>
                     </md-tab-label>
                 </md-tab>
-                <md-tab ng-repeat="tab in $ctrl.caches" label="{{tab.title}}">
+                <md-tab ng-repeat="tab in $ctrl.caches" label="{{tab.title}}" ng-hide="$ctrl.hide">
                     <div class="tab{{$index%4}}" style="padding: 25px; text-align: center;">
                         <md-content layout="column">
                             <md-input-container>
                                 <label>Cache Size</label>
                                 <md-select ng-model="tab.cacheSize" placeholder="Select a Cache Size"
-                                           ng-change="updateCache(tab.cacheSize, $index%4, 'size')" ng-disabled="!($ctrl.policySet && $ctrl.blockSizeSet)">
+                                           ng-change="updateCache(tab.cacheSize, $index%4, 'size')" ng-disabled="!($ctrl.policySet && $ctrl.blockSizeSet)" ng-hide="$ctrl.hide">
                                     <md-option ng-repeat="size in cacheSizes" value="{{size}}">
                                         {{size}}
                                     </md-option>
@@ -145,7 +143,7 @@
                             <md-input-container>
                                 <label>Associativity</label>
                                 <md-select ng-model="tab.Associativity" placeholder="Select an Associativity"
-                                           ng-change="updateCache(tab.Associativity, $index%4, 'associativity')" ng-disabled="!($ctrl.policySet && $ctrl.blockSizeSet)">
+                                           ng-change="updateCache(tab.Associativity, $index%4, 'associativity')" ng-disabled="!($ctrl.policySet && $ctrl.blockSizeSet)" ng-hide="$ctrl.hide">
                                     <md-option ng-repeat="associativity in $ctrl.caches[$index%4].associativities" value="{{associativity}}">
                                         {{associativity}}
                                     </md-option>
@@ -161,6 +159,26 @@
                 <md-subheader class="md-no-sticky">{{$ctrl.fileName}}</md-subheader>
                 <md-button class="md-primary md-raised" ng-click="$ctrl.handleUpload()" ng-disabled="$ctrl.fileName.length != 0" type="submit" style="margin-right: 0;">Upload</md-button>
             </md-content>
+
+            <!-- Control Flow Buttons -->
+            <md-content layout="row" layout-align="space-around center">
+                <md-button class="md-icon-button" ng-disabled="$ctrl.fileName.length == 0"><i class="material-icons">skip_previous</i></md-button>
+                <md-button class="md-icon-button" ng-disabled="$ctrl.fileName.length == 0" ng-click= "$ctrl.showSideBar();"><i class="material-icons">pause</i></md-button>
+                <md-button class="md-icon-button" ng-disabled="$ctrl.fileName.length == 0" ng-click= "$ctrl.hideSideBar();"><i class="material-icons">play_arrow</i></md-button>
+                <md-button class="md-icon-button" ng-disabled="$ctrl.fileName.length == 0"><i class="material-icons">skip_next</i></md-button>
+                <md-button class="md-icon-button" ng-disabled="$ctrl.fileName.length == 0"><i class="material-icons">replay</i></md-button>
+            </md-content>
+            <md-content layout="row" layout-align="center" style="padding-top: 25px; padding-right: 10px;">
+                <div layout layout-align="center center">
+                    <span class="md-body-1">Speed</span>
+                </div>
+                <div style="width:100%;padding:10px">
+                    <md-slider flex class="md-primary" md-discrete ng-model="$ctrl.speedRating" step="1" min="1" max="5" aria-label="rating" ng-disabled="$ctrl.fileName.length == 0">
+                </div>
+                </md-slider>
+            </md-content>
+
+            <!-- Memory Acess Queue -->
             <md-subheader class="md-no-sticky">Memory Access Queue</md-subheader>
             <md-table-container style="height:150px">
                 <table md-table>
@@ -182,24 +200,8 @@
                     </tbody>
                 </table>
             </md-table-container>
-
-            <!-- Control Flow Buttons -->
-            <md-content layout="row" layout-align="space-around center">
-                <md-button class="md-icon-button"><i class="material-icons">skip_previous</i></md-button>
-                <md-button class="md-icon-button"><i class="material-icons">pause</i></md-button>
-                <md-button class="md-icon-button"><i class="material-icons">play_arrow</i></md-button>
-                <md-button class="md-icon-button"><i class="material-icons">skip_next</i></md-button>
-                <md-button class="md-icon-button"><i class="material-icons">replay</i></md-button>
-            </md-content>
-            <md-content layout="row" layout-align="center" style="padding-top: 25px; padding-right: 10px;">
-                <div layout layout-align="center center">
-                    <span class="md-body-1">Speed</span>
-                </div>
-                <div style="width:100%;padding:10px">
-                    <md-slider flex class="md-primary" md-discrete ng-model="$ctrl.speedRating" step="1" min="1" max="5" aria-label="rating">
-                </div>
-                </md-slider>
-            </md-content>
         </md-content>
+        <div style="min-height: 430px" ng-hide="!$ctrl.hide">
+        </div>
     </section>
 </div>

--- a/src/cacheDisplay.js
+++ b/src/cacheDisplay.js
@@ -19,6 +19,7 @@ function CacheDisplayController($scope, simDriver, fileParser) {
     ctrl.policySet = false;
     ctrl.blockSizeSet = false;
     ctrl.disableDeleteCache = true;
+    ctrl.hide = false;
 
     var B_min = 3, B_max = 7;
 
@@ -39,6 +40,14 @@ function CacheDisplayController($scope, simDriver, fileParser) {
         C: 1,
         S: 1
     }];
+
+    ctrl.hideSideBar = function() {
+        ctrl.hide = true;
+    }
+
+    ctrl.showSideBar = function() {
+        ctrl.hide = false;
+    }
 
     ctrl.clickCache = function(index) {
         $scope.$parent.changeView(index)


### PR DESCRIPTION
Please make sure that the following are true:
1) When first running the simulation the L1 should take up most of the cache display and the simulation controller with the buttons and slider should be disable
2) Select cache details  and details for L1
2) Add L2 which should result in L1 to be compressed to the left and L2 to be the larger of the two in the right. add cache details for L2
3) Add L3 which should cause the L3 cache to appear in the bottom with L1 and L2 on top. add details to L3.
4) Upload trace file which enables the animation controller
5) run simulation. Running the simulation should result in the cache detail info to disappear and the simulation controller to be shifted up
6)  Cache Display should stay the same with no major changes in the size of the caches or the cache display itself
7)  pause the simulation which should cause the cache detail to comeback and push down the simulator controller
8) start deleting the cashes and they should be resizing accordingly.

If all these conditions are met then this issue should be solved.