### PR TITLE
Issue 67 and 61 fixed

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,4 +76,8 @@ simulator.controller('IndexController', ['$scope', function($scope) {
         }
         $scope.$broadcast('cacheInfoUpdated', ctrl.cacheInfo);
     });
+
+    $scope.$on('inputUpdateCanvas', function(event, data) {
+        $scope.$broadcast('displayUpdateCanvas');
+    });
 }]);

--- a/src/browser/cacheDisplay.html
+++ b/src/browser/cacheDisplay.html
@@ -5,10 +5,10 @@
     <!-- <div ng-cloak xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html"> -->
     <div ng-cloak>
         <!--Cache Display-->
-        <md-content layout="column" layout-padding md-theme="docs-dark">
-            <div ng-app="Simulator" ng-controller="IndexController" layout="row">
+        <md-content layout="column" layout-padding md-theme="docs-dark" flex>
+            <div id="canvas1" ng-app="Simulator" ng-controller="IndexController" layout="row" flex>
                 <!--L1-->
-                <md-card ng-show="$ctrl.cacheInfo.caches[0].active" ng-click="$ctrl.clickCache(1)" flex>
+                <md-card id="L1" ng-show="$ctrl.cacheInfo.caches[0]" ng-click="$ctrl.clickCache(1)" flex>
                     <md-card-title layout="column">
                         <md-card-title-text>
                             <div layout="row" layout-align="space-between">
@@ -24,12 +24,12 @@
                         <md-card-title-media>
                             <div class="md-media-lg card-media"></div>
                         </md-card-title-media>
-                        <md-button ng-click="$ctrl.removeCache(0, $event)" ng-disabled="$ctrl.disableDeleteCache"><i class="material-icons">delete</i></md-button>
+                        <md-button ng-click="$ctrl.removeCache(0, $event)" ng-disabled="$ctrl.cacheInfo.disableDeleteCache"><i class="material-icons">delete</i></md-button>
 
                     </md-card-title>
                 </md-card>
                 <!--L2-->
-                <md-card ng-show="$ctrl.cacheInfo.caches[1].active" ng-click="$ctrl.clickCache(2)" flex="60">
+                <md-card id="L2" ng-show="$ctrl.cacheInfo.caches[1]" ng-click="$ctrl.clickCache(2)" flex>
                     <md-card-title layout="column">
                         <md-card-title-text>
                             <div layout="row" layout-align="space-between">
@@ -46,13 +46,13 @@
                         <md-card-title-media>
                             <div class="md-media-lg card-media"></div>
                         </md-card-title-media>
-                        <md-button ng-click="$ctrl.removeCache(1, $event)"><i class="material-icons">delete</i></md-button>
+                        <md-button ng-click="$ctrl.removeCache(1, $event)" ng-disabled="$ctrl.cacheInfo.disableDeleteCache"><i class="material-icons">delete</i></md-button>
                     </md-card-title>
                 </md-card>
             </div>
-            <div ng-controller="IndexController" layout="column">
+            <div id="canvas2" ng-controller="IndexController" layout="column">
                 <!--L3-->
-                <md-card ng-show="$ctrl.cacheInfo.caches[2].active" ng-click="$ctrl.clickCache(3)">
+                <md-card id="L3" ng-show="$ctrl.cacheInfo.caches[2]" ng-click="$ctrl.clickCache(3)" flex>
                     <md-card-title layout="column">
                         <md-card-title-text>
                             <div layout="row" layout-align="space-between">
@@ -68,7 +68,7 @@
                         <md-card-title-media>
                             <div class="md-media-lg card-media"></div>
                         </md-card-title-media>
-                        <md-button ng-click="$ctrl.removeCache(2, $event)"><i class="material-icons">delete</i></md-button>
+                        <md-button ng-click="$ctrl.removeCache(2, $event)" ng-disabled="$ctrl.cacheInfo.disableDeleteCache"><i class="material-icons">delete</i></md-button>
                     </md-card-title>
                 </md-card>
             </div>

--- a/src/browser/cacheDisplay.js
+++ b/src/browser/cacheDisplay.js
@@ -36,6 +36,8 @@ function CacheDisplayController($scope) {
             }
             ctrl.cacheInfo.caches = caches;
         }
+        $scope.showL3();
+        $scope.updateCacheCanvas();
         $scope.emit('updateCacheInfo', ctrl.cacheInfo);
     };
 
@@ -62,4 +64,111 @@ function CacheDisplayController($scope) {
     $scope.$on('cacheInfoUpdated', function(event, data) {
         ctrl.cacheInfo = data;
     });
+
+
+    // Here is the code that updates the canvas based on cache sizes    
+    let canvas1 = document.getElementById("canvas1");
+    canvas1.style.height = "720px";
+    canvas1.style.flex = "auto";
+
+    let canvas2 = document.getElementById("canvas2");
+    canvas2.style.flex = "";
+
+    let l1 = document.getElementById("L1");
+    l1.style.flex = 1;
+    let l2 = document.getElementById("L2");
+    l2.style.flex = 1;
+    let l3 = document.getElementById("L3");
+    l3.style.flex = 1;
+
+    $scope.showL3 = function() {
+        if (ctrl.cacheInfo.caches.length === 3) {
+            canvas2.style.flex = "auto";
+            canvas2.style.height = "370px";
+            canvas1.style.height = "370px";
+        }
+        else {
+            canvas1.style.height = "720px";
+        }
+    };
+
+    $scope.$on('displayUpdateCanvas', function(event, data) {
+        $scope.showL3();
+        $scope.updateCacheCanvas();
+    });
+
+    $scope.updateCacheCanvas = function() {
+        if (ctrl.cacheInfo.caches.length === 1) {
+            l1.style.flex = 1;
+            l2.style.flex = 1;
+            canvas2.style.flex = "";
+            canvas2.style.height = "0%";
+        }
+        if (ctrl.cacheInfo.caches.length === 2) {
+            canvas2.style.flex = "";
+            canvas2.style.height = "0%";
+            if (ctrl.cacheInfo.caches[0].size !== "Not Set" && ctrl.cacheInfo.caches[1].size !== "Not Set") {
+                let l1Size = ctrl.cacheInfo.caches[0].size;
+                let l2Size = ctrl.cacheInfo.caches[1].size;
+                let ratio = l2Size / l1Size;
+                if (ratio < 0.3) {
+                    ratio = 0.3;
+                } else if (ratio > 3) {
+                    ratio = 3
+                }
+                l1.style.flex = 1;
+                l2.style.flex = ratio;
+            }
+        }
+        if (ctrl.cacheInfo.caches.length === 3) {
+            if (ctrl.cacheInfo.caches[0].size !== "Not Set" && ctrl.cacheInfo.caches[1].size !== "Not Set" && ctrl.cacheInfo.caches[1].size === "Not Set") {
+                let l1Size = ctrl.cacheInfo.caches[0].size;
+                let l2Size = ctrl.cacheInfo.caches[1].size;
+                let ratio = l2Size / l1Size;
+                if (ratio < 0.3) {
+                    ratio = 0.3;
+                } else if (ratio > 3) {
+                    ratio = 3
+                }
+
+                l1.style.flex = 1;
+                l2.style.flex = ratio;
+            } else if (ctrl.cacheInfo.caches[0].size !== "Not Set" && ctrl.cacheInfo.caches[1].size !== "Not Set" && ctrl.cacheInfo.caches[1].size !== "Not Set") {
+                canvas2.style.flex = "";
+                let l1Size = ctrl.cacheInfo.caches[0].size;
+                let l2Size = ctrl.cacheInfo.caches[1].size;
+                let l3Size = ctrl.cacheInfo.caches[2].size;
+                let canvas1heightRatio = 0;
+                let canvas1widthRatio = l2Size / l1Size;
+                if (canvas1widthRatio < 0.3) {
+                    canvas1widthRatio = 0.3;
+                } else if (canvas1widthRatio > 3) {
+                    canvas1widthRatio = 3
+                }
+                let ratioSize = parseInt(l1Size) + parseInt(l2Size);
+                let canvas2Ratio = l3Size / ratioSize;
+
+                canvas2Ratio = canvas2Ratio * 40;
+                l1.style.flex = 1;
+                l2.style.flex = canvas1widthRatio;
+                if (canvas2Ratio < 30) {
+                    canvas2Ratio = 30;
+                }
+                else if (canvas2Ratio > 90) {
+                    canvas2Ratio = 90;
+                }
+                canvas2Ratio = canvas2Ratio / 100;
+                canvas2Ratio = canvas2Ratio * 720;
+                if (canvas2Ratio < 250) {
+                    canvas2Ratio = 250;
+                }
+                else if (canvas2Ratio > 500) {
+                    canvas2Ratio = 500;
+                }
+                canvas1heightRatio = 740 - canvas2Ratio;
+                canvas2.style.height = canvas2Ratio.toString() + "px";
+                canvas1.style.height = canvas1heightRatio.toString() + "px";
+            }
+        }
+    };
 }

--- a/src/browser/cacheInput.html
+++ b/src/browser/cacheInput.html
@@ -5,7 +5,7 @@
     <div ng-cloak id="sidebar">
         <!--Cache Input-->
         <div layout="column" layout-padding md-theme="docs-light" class="md-inline-form">
-            <md-input-container ng-hide="hide">
+            <md-input-container ng-hide="$ctrl.hideSidebar">
                 <label>Replacement Policy</label>
                 <md-select ng-model="policy" placeholder="Select a Policy" ng-change="$ctrl.setPolicy()">
                     <md-option ng-repeat="policy in $ctrl.cacheInfo.policies" value="{{policy}}">
@@ -14,8 +14,8 @@
                 </md-select>
             </md-input-container>
 
-            <md-input-container ng-hide="hide">
-                <label>Block Size</label>
+            <md-input-container ng-hide="$ctrl.hideSidebar">
+                <label ng-hide="$ctrl.hideSidebar">Block Size</label>
                 <md-select ng-model="blockSize" ng-change="$ctrl.setBlockSize()" placeholder="Select a Block Size">
                     <md-option ng-repeat="size in $ctrl.cacheInfo.blockSizes" value="{{size}}">
                         {{size}}
@@ -23,8 +23,8 @@
                 </md-select>
             </md-input-container>
 
-            <md-tabs md-selected="selectedIndex" md-border-bottom md-autoselect ng-hide="$ctrl.hide">
-                <md-tab ng-disabled="$ctrl.cacheInfo.caches.length === 3" ng-hide="$ctrl.hide">
+            <md-tabs md-selected="selectedIndex" md-border-bottom md-autoselect ng-hide="$ctrl.hideSidebar">
+                <md-tab ng-disabled="$ctrl.cacheInfo.caches.length === 3" ng-hide="$ctrl.hideSidebar">
                     <md-tab-label class="add-button">
                         <md-button class="md-icon-button" ng-click="$ctrl.addCache()" ng-hide="$ctrl.hideSidebar"><i class="material-icons">add</i></md-button>
                     </md-tab-label>
@@ -35,7 +35,7 @@
                             <md-input-container>
                                 <label>Cache Size</label>
                                 <md-select ng-model="tab.cacheSize" placeholder="Select a Cache Size"
-                                           ng-change="updateCache(tab.cacheSize, $index%4, 'size')" ng-disabled="!($ctrl.cacheInfo.policySet && $ctrl.cacheInfo.blockSizeSet)" ng-hide="$ctrl.hide">
+                                           ng-change="updateCache(tab.cacheSize, $index%4, 'size')" ng-disabled="!($ctrl.cacheInfo.policySet && $ctrl.cacheInfo.blockSizeSet)" ng-hide="$ctrl.hideSidebar">
                                     <md-option ng-repeat="size in $ctrl.cacheInfo.cacheSizes" value="{{size}}">
                                         {{size}}
                                     </md-option>
@@ -98,8 +98,5 @@
                     </tbody>
                 </table>
             </md-table-container>
-        </div>
-        <div id="hide-sidebar" ng-hide="!$ctrl.hideSidebar">
-        </div>
     </div>
 </body>

--- a/src/browser/cacheInput.js
+++ b/src/browser/cacheInput.js
@@ -44,6 +44,7 @@ function CacheInputController($scope, simDriver, fileParser) {
             ctrl.cacheInfo.disableDeleteCache = false;
         }
         //Emit sends an event to the parent controller/component
+        $scope.$emit('inputUpdateCanvas', ctrl.cacheInfo);
         $scope.$emit('updateCacheInfo', ctrl.cacheInfo);
     };
 
@@ -102,6 +103,7 @@ function CacheInputController($scope, simDriver, fileParser) {
             c.associativity = item;
         }
         ctrl.cacheInfo.caches[index] = c;
+        $scope.$emit('inputUpdateCanvas', ctrl.cacheInfo);
         $scope.$emit('updateCacheInfo', ctrl.cacheInfo);
     };
     


### PR DESCRIPTION
Playing the play button should cause the side bar cache input details to disappear and the canvas size should stay the same size regardless of number of caches added.

Size of canvas is approximate to the size of the sidebar.

Also passed into this pull request my previous work on re scaling the cache according to their size on the canvas display that was previously merged into master