### PR TITLE
added display of dummy data in format needed from simulator state

### DIFF
--- a/src/browser/cacheDetail.css
+++ b/src/browser/cacheDetail.css
@@ -11,6 +11,10 @@
 	width: 10%;
 }
 
+.address {
+    width = 60%;
+}
+
 td,th {
 	border: 1px solid #999;
 	padding: 0.5rem;

--- a/src/browser/cacheDetail.css
+++ b/src/browser/cacheDetail.css
@@ -1,18 +1,17 @@
-.center {
-	text-align: center;
-}
-
 .tableCollapse {
 	border-collapse: collapse;
 }
 
 .index {
-	text-align: center;
 	width: 10%;
 }
 
 .address {
-    width = 60%;
+    width : 60%;
+}
+
+.validDirty {
+    width : 5%;
 }
 
 td,th {

--- a/src/browser/cacheDetail.html
+++ b/src/browser/cacheDetail.html
@@ -22,7 +22,7 @@
             <tr md-row ng-repeat="x in [].constructor($ctrl.getIndicesSize()) track by $index">
               <td class="index" md-cell> {{$index}} </td>
               <td md-cell  ng-click="$ctrl.openModal($event,'modal-' + $parent.$index + $index, 'modal-' + $parent.$index + $index + -tag)">
-                <span ng-attr-id="{{ 'modal-' + $parent.$index + $index + 'tag'}}"> {{$ctrl.modals['modal-' + $parent.$index + $index]['tag']}}</span>
+                <span ng-attr-id="{{ 'modal-' + $parent.$index + $index + 'tag'}}"> {{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['tag']}}</span>
                 <!-- The Modal -->
                   <div id="{{ 'modal-' + $parent.$index + $index}}" class="modal">
                     <!-- Modal content -->
@@ -32,7 +32,7 @@
                         <h2>{{$parent.$index}}{{$index}}</h2>
                       </div>
                       <div class="modal-body">
-                        <p>{{'modal-' + $parent.$index + $index + ': tag = ' + $ctrl.modals['modal-' + $parent.$index + $index]['tag']}}</p>
+                        <p>{{'modal-' + $parent.$index + $index + ': tag = ' + $ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['tag']}}</p>
                         <table id="fillWidthAndHeight">
                           <thead md-head md-order="query.order">
                             <tr md-row>
@@ -41,7 +41,7 @@
                             </tr>
                             <tbody>
                               <tr md-row ng-repeat="x in [].constructor($ctrl.getBlockSize()) track by $index"> 
-                                <td> {{$ctrl.modals['modal-' + $parent.$parent.$index + $parent.$index]['block'][$index].toString(2)}} </td>
+                                <td> {{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$parent.$index + $parent.$index]['block'][$index].toString(2)}} </td>
                                 <td> {{$index.toString(2)}} </td>
                               </tr>
                             </tbody>

--- a/src/browser/cacheDetail.html
+++ b/src/browser/cacheDetail.html
@@ -22,7 +22,7 @@
             <tr md-row ng-repeat="x in [].constructor($ctrl.getIndicesSize()) track by $index">
               <td class="index" md-cell> {{$index}} </td>
               <td md-cell  ng-click="$ctrl.openModal($event,'modal-' + $parent.$index + $index, 'modal-' + $parent.$index + $index + -tag)">
-                <span ng-attr-id="{{ 'modal-' + $parent.$index + $index + 'tag'}}"> 0xDEADBEEF </span>
+                <span ng-attr-id="{{ 'modal-' + $parent.$index + $index + 'tag'}}"> {{$ctrl.modals['modal-' + $parent.$index + $index]['tag']}}</span>
                 <!-- The Modal -->
                   <div id="{{ 'modal-' + $parent.$index + $index}}" class="modal">
                     <!-- Modal content -->
@@ -32,19 +32,17 @@
                         <h2>{{$parent.$index}}{{$index}}</h2>
                       </div>
                       <div class="modal-body">
-                        <p>{{'modal-' + $parent.$index + $index + ': tag = 0xDEADBEEF'}}</p>
+                        <p>{{'modal-' + $parent.$index + $index + ': tag = ' + $ctrl.modals['modal-' + $parent.$index + $index]['tag']}}</p>
                         <table id="fillWidthAndHeight">
                           <thead md-head md-order="query.order">
                             <tr md-row>
-                              <th class="index" md-column>Address</th>
-                              <th class="center" md-column>Index</th>
+                              <th class="address" md-column>Address</th>
                               <th class="center" md-column>Offset</th>
                             </tr>
                             <tbody>
                               <tr md-row ng-repeat="x in [].constructor($ctrl.getBlockSize()) track by $index"> 
-                                <td> Address </td>
-                                <td> Index </td>
-                                <td> {{$index}} </td>
+                                <td> {{$ctrl.modals['modal-' + $parent.$parent.$index + $parent.$index]['block'][$index].toString(2)}} </td>
+                                <td> {{$index.toString(2)}} </td>
                               </tr>
                             </tbody>
                           </thead>

--- a/src/browser/cacheDetail.html
+++ b/src/browser/cacheDetail.html
@@ -47,7 +47,7 @@
                             </tr>
                             <tbody>
                               <tr md-row ng-repeat="x in [].constructor($ctrl.getBlockSize()) track by $index"> 
-                                <td> {{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$parent.$index + $parent.$index]['block'][$index].toString(2)}} </td>
+                                <td> 0x{{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$parent.$index + $parent.$index]['block'][$index].toString(16)}} </td>
                                 <td> {{$index.toString(2)}} </td>
                               </tr>
                             </tbody>

--- a/src/browser/cacheDetail.html
+++ b/src/browser/cacheDetail.html
@@ -16,6 +16,8 @@
             <tr md-row>
               <th class="index" md-column>Index</th>
               <th class="center" md-column>Tag</th>
+              <th class="validDirty" md-column>Valid</th>
+              <th class="validDirty" md-column>Dirty</th>
             </tr>
           </thead>
           <tbody md-body>
@@ -29,10 +31,14 @@
                     <div class="modal-content">
                       <div class="modal-header">
                         <span class="close" ng-click="$ctrl.closeModalSpan($event)">&times;</span>
-                        <h2>{{$parent.$index}}{{$index}}</h2>
+                        <h2>Block associated with given tag: {{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['tag']}}</h2>
                       </div>
                       <div class="modal-body">
-                        <p>{{'modal-' + $parent.$index + $index + ': tag = ' + $ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['tag']}}</p>
+                        <p>
+                        Cache: {{$ctrl.activeCache}} <br>
+                        Way: {{$parent.$index}} <br>
+                        Index: {{$index}} 
+                        </p>
                         <table id="fillWidthAndHeight">
                           <thead md-head md-order="query.order">
                             <tr md-row>
@@ -51,6 +57,8 @@
                     </div>
                   </div>
               </td>
+              <td class = 'validDirty'>{{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['valid']}}</td>
+              <td class = 'validDirty'>{{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['dirty']}}</td>
             </tr>
           </tbody>
         </table>

--- a/src/browser/cacheDetail.js
+++ b/src/browser/cacheDetail.js
@@ -17,9 +17,17 @@ function CacheDetailController($scope, SimDriver) {
     ctrl.index = 0;
     //ctrl.modals = {};
     ctrl.modals = {
-        'modal-01' : {
-            'tag' : 10110,
-            'block' : [...Array(32).keys()].map(x => x+2000)
+        'L1' : {
+            'modal-01' : {
+                'tag' : 10110,
+                'block' : [...Array(32).keys()].map(x => x+2000)
+            }
+        },
+        'L2' : {
+            'modal-00' : {
+                'tag' : 11000,
+                'block' : [...Array(32).keys()].map(x => x+7000)
+            }
         }
     }
 
@@ -34,13 +42,16 @@ function CacheDetailController($scope, SimDriver) {
     });
 
     $scope.$on('updateModals', function (event, data) {
-        let way = data.way;
-        let index = data.index;
-        let tag = data.tag;
-        let block = data.block; //Array of memory addresses associated with given tag
-        ctrl.modals['modal-'+way+index] = {
-            'tag' : tag,
-            'block' : block
+        for (action in data) {
+            let cacheLevel = action.level;
+            let way = action.way;
+            let index = action.index;
+            let tag = action.tag;
+            let block = action.block; //Array of memory addresses associated with given tag
+            ctrl.modals[cacheLevel]['modal-'+way+index] = {
+                'tag' : tag,
+                'block' : block
+            }
         }
     })
 

--- a/src/browser/cacheDetail.js
+++ b/src/browser/cacheDetail.js
@@ -20,13 +20,17 @@ function CacheDetailController($scope, SimDriver) {
         'L1' : {
             'modal-01' : {
                 'tag' : 10110,
-                'block' : [...Array(32).keys()].map(x => x+2000)
+                'block' : [...Array(32).keys()].map(x => x+2000),
+                'valid' : 1,
+                'dirty' : 0
             }
         },
         'L2' : {
             'modal-00' : {
                 'tag' : 11000,
-                'block' : [...Array(32).keys()].map(x => x+7000)
+                'block' : [...Array(32).keys()].map(x => x+7000),
+                'valid' : 1,
+                'dirty' : 0
             }
         }
     }
@@ -48,9 +52,13 @@ function CacheDetailController($scope, SimDriver) {
             let index = action.index;
             let tag = action.tag;
             let block = action.block; //Array of memory addresses associated with given tag
+            let valid = action.valid;
+            let dirty = action.dirty;
             ctrl.modals[cacheLevel]['modal-'+way+index] = {
                 'tag' : tag,
-                'block' : block
+                'block' : block,
+                'valid' : valid,
+                'dirty' : dirty
             }
         }
     })

--- a/src/browser/cacheDetail.js
+++ b/src/browser/cacheDetail.js
@@ -15,6 +15,13 @@ function CacheDetailController($scope, SimDriver) {
     ctrl.activeCache = 'L1';
     ctrl.maq = [];
     ctrl.index = 0;
+    //ctrl.modals = {};
+    ctrl.modals = {
+        'modal-01' : {
+            'tag' : 10110,
+            'block' : [...Array(32).keys()].map(x => x+2000)
+        }
+    }
 
     $scope.$on('updatedNavs', function(event, data, index) {
         ctrl.activeCache = data.buttonTitle;
@@ -25,6 +32,17 @@ function CacheDetailController($scope, SimDriver) {
     $scope.$on('cacheInfoUpdated', function(event, data) {
         ctrl.cacheInfo = data;
     });
+
+    $scope.$on('updateModals', function (event, data) {
+        let way = data.way;
+        let index = data.index;
+        let tag = data.tag;
+        let block = data.block; //Array of memory addresses associated with given tag
+        ctrl.modals['modal-'+way+index] = {
+            'tag' : tag,
+            'block' : block
+        }
+    })
 
     ctrl.getAssociativity = function(event) {
         return parseInt(ctrl.cacheInfo.caches[ctrl.index].associativity);


### PR DESCRIPTION
Setup showing dummy data with given default cache parameters.  This PR also takes into account the format I need to data to be delivered in. 
```javascript
        for (action in data) {
            let cacheLevel = action.level;
            let way = action.way;
            let index = action.index;
            let tag = action.tag;
            let block = action.block; //Array of memory addresses associated with given tag
            let valid = action.valid;
            let dirty = action.dirty;
            ctrl.modals[cacheLevel]['modal-'+way+index] = {
                'tag' : tag,
                'block' : block,
                'valid' : valid,
                'dirty' : dirty
            }
        }
```
Any object delivering the following attributes to the cache details controller should suffice.