### PR TITLE
issue 73 coloring of different states as well as slight changes in mock sim

### DIFF
--- a/src/browser/cacheDetail.html
+++ b/src/browser/cacheDetail.html
@@ -1,68 +1,268 @@
-<!-- Below is from a demo, need to change content -->
-<head>
-    <link href="src/browser/cacheDetail.css" rel="stylesheet">
-</head>
-<md-toolbar id="activeCacheBanner" class="md-table-toolbar md-default">
-  <div class="md-toolbar-tools">
-    <span>{{$ctrl.activeCache}}</span>
-  </div>
-</md-toolbar>
-<md-table-container>
-  <table id="fillWidth">
-    <tr>
-      <td ng-repeat="x in $ctrl.numSets() track by $index">
-        <table class="tableCollapse" md-table md-row-select multiple  md-progress="promise">
-          <thead md-head md-order="query.order">
-            <tr md-row>
-              <th class="index" md-column>Index</th>
-              <th class="center" md-column>Tag</th>
-              <th class="validDirty" md-column>Valid</th>
-              <th class="validDirty" md-column>Dirty</th>
-            </tr>
-          </thead>
-          <tbody md-body>
-            <tr md-row ng-repeat="x in $ctrl.numCacheRows() track by $index">
-              <td class="index" md-cell> {{$index}} </td>
-              <td md-cell  ng-click="$ctrl.openModal($event,'modal-' + $parent.$index + $index, 'modal-' + $parent.$index + $index + -tag)">
-                <span ng-attr-id="{{ 'modal-' + $parent.$index + $index + 'tag'}}"> {{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['tag']}}</span>
-                <!-- The Modal -->
-                  <div id="{{ 'modal-' + $parent.$index + $index}}" class="modal">
-                    <!-- Modal content -->
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <span class="close" ng-click="$ctrl.closeModalSpan($event)">&times;</span>
-                        <h2>Block associated with given tag: {{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['tag']}}</h2>
-                      </div>
-                      <div class="modal-body">
-                        <p>
-                        Cache: {{$ctrl.activeCache}} <br>
-                        Way: {{$parent.$index}} <br>
-                        Index: {{$index}} 
-                        </p>
-                        <table id="fillWidthAndHeight">
-                          <thead md-head md-order="query.order">
-                            <tr md-row>
-                              <th class="address" md-column>Address</th>
-                              <th class="center" md-column>Offset</th>
-                            </tr>
-                            <tbody>
-                              <tr md-row ng-repeat="x in $ctrl.numBlockRows() track by $index">
-                                <td> 0x{{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$parent.$index + $parent.$index]['block'][$index].toString(16)}} </td>
-                                <td> {{$index.toString(2)}} </td>
-                              </tr>
-                            </tbody>
-                          </thead>
-                        </table>
-                      </div>
-                    </div>
-                  </div>
-              </td>
-              <td class = 'validDirty'>{{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['valid']}}</td>
-              <td class = 'validDirty'>{{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['dirty']}}</td>
-            </tr>
-          </tbody>
-        </table>
-      </td>
-    </tr>
-  </table>
-</md-table-container>
+'use strict';
+
+angular.module('Simulator').component('cacheDetail', {
+    templateUrl: 'src/browser/cacheDetail.html',
+    controller: ['$scope', 'SimDriver', CacheDetailController],
+    bindings: {}
+});
+
+function CacheDetailController($scope, SimDriver) {
+
+    let ctrl = this;
+
+    ctrl.cacheInfo = $scope.$parent.initialCacheInfo;
+
+    ctrl.posInQueue = 0;
+    ctrl.overallAge = 0;
+    ctrl.activeCache = 'L1';
+    ctrl.maq = [];
+    ctrl.index = 0;
+    ctrl.modals = {};
+    ctrl.modals = {
+        'L1' : {},
+        'L2' : {},
+        'L3': {}
+    };
+
+    $scope.$on('updatedNavs', function(event, data, index) {
+        ctrl.activeCache = data.buttonTitle;
+        ctrl.maq = SimDriver.setQueue(SimDriver.getMemAcceses());
+        ctrl.index = index;
+    });
+
+    $scope.$on('cacheInfoUpdated', function(event, data) {
+        ctrl.cacheInfo = data;
+    });
+
+    $scope.$on('updateModals', function (event, data) {
+        console.log('updating modals', data);
+        ctrl.overallAge++;
+        for (let action of data) {
+            console.log(action);
+            let address = action.address
+            let cacheLevel = action.level;
+            let way = action.way;
+            let index = action.index;
+            let tag = action.tag;
+            let block = action.block; //Array of memory addresses associated with given tag
+            let valid = action.valid;
+            let dirty = action.dirty;
+            let age = ctrl.overallAge;
+            let position = document.getElementById(index.toString());
+            if (ctrl.modals[cacheLevel]['modal-'+way+index] == null) {
+                position.style.backgroundColor = "#7FFF00";
+                let span = position.getElementsByTagName('span');
+                span[0].innerHTML = tag;
+                ctrl.modals[cacheLevel]['modal-'+way+index] = {
+                    'tag' : tag,
+                    'block' : block,
+                    'valid' : valid,
+                    'dirty' : dirty,
+                    'age' : age,
+                    'fu' : 0,
+                    'pos' : ctrl.posInQueue++,
+                };
+            } else {
+                if (ctrl.modals[cacheLevel]['modal-'+way+index]['tag'] == tag) {
+                    position.style.backgroundColor = "#6767FF";
+                    let span = position.getElementsByTagName('span');
+                    span[0].innerHTML = tag;
+                    let fu = ctrl.modals[cacheLevel]['modal-'+way+index]['fu'];
+                    ctrl.modals[cacheLevel]['modal-'+way+index] = {
+                        'tag' : tag,
+                        'block' : block,
+                        'valid' : valid,
+                        'dirty' : dirty,
+                        'age' : age,
+                        'fu' : fu + 1,
+                        'pos' : ctrl.posInQueue,
+                    };
+                    return;
+                }
+                let numWays = ctrl.getAssociativity();
+                let checker = true;
+                while (way < (numWays - 1)) {
+                    way++;
+                    if (ctrl.modals[cacheLevel]['modal-'+way+index] == null) {
+                        let correctIndex = (ctrl.getIndicesSize() * parseInt(way)) + parseInt(index);
+                        position = document.getElementById(correctIndex.toString());
+                        position.style.backgroundColor = "#7FFF00";
+                        let span = position.getElementsByTagName('span');
+                        span[0].innerHTML = tag;
+                        ctrl.modals[cacheLevel]['modal-'+way+index] = {
+                            'tag' : tag,
+                            'block' : block,
+                            'valid' : valid,
+                            'dirty' : dirty,
+                            'age' : age,
+                            'fu' : 0,
+                            'pos' : ctrl.posInQueue++,
+                        };
+                        checker = false;
+                        break;
+                    }
+                }
+                if (checker) {
+                    way = action.way;
+                    let policy = ctrl.cacheInfo.policy;
+
+                    if (policy == "LRU") {
+                        let size = ctrl.getIndicesSize();
+                        let numWays = ctrl.getAssociativity();
+                        let youngest = age;
+                        let aIndex = 0;
+                        let aWay = 0;
+                        while (way < numWays) {
+                            for (let i = 0; i < size; i++) {
+                                let aPos = ctrl.modals[cacheLevel]['modal-'+way+i];
+                                if (aPos != null) {
+                                    if (aPos['age'] < youngest) {
+                                        youngest = aPos['age'];
+                                        aIndex = i;
+                                        aWay = way;
+                                    }
+                                }
+                            }
+                            way++;
+                        }
+                        let correctIndex = (ctrl.getIndicesSize() * parseInt(aWay)) + parseInt(aIndex);
+                        position = document.getElementById(correctIndex.toString());
+                        position.style.backgroundColor = "#FF7F7F";
+                        let span = position.getElementsByTagName('span');
+                        span[0].innerHTML = tag;
+                        let fu = ctrl.modals[cacheLevel]['modal-'+aWay+aIndex]['fu'];
+                        ctrl.modals[cacheLevel]['modal-'+aWay+aIndex] = {
+                            'tag' : tag,
+                            'block' : block,
+                            'valid' : valid,
+                            'dirty' : dirty,
+                            'age' : age,
+                            'fu' : fu + 1,
+                            'pos' : ctrl.posInQueue++,
+                        };
+                    }
+                    if (policy == "LFU") {
+                        let size = ctrl.getIndicesSize();
+                        let numWays = ctrl.getAssociativity();
+                        let lfu = age; //age will always be >= lfu;
+                        let aIndex = 0;
+                        let aWay = 0;
+                        while (way < numWays) {
+                            for (let i = 0; i < size; i++) {
+                                let aPos = ctrl.modals[cacheLevel]['modal-'+way+i];
+                                if (aPos != null) {
+                                    if (aPos['fu'] < lfu) {
+                                        lfu = aPos['fu'];
+                                        aIndex = i;
+                                        aWay = way;
+                                    }
+                                }
+                            }
+                            way++;
+                        }
+                        let correctIndex = (ctrl.getIndicesSize() * parseInt(aWay)) + parseInt(aIndex);
+                        position = document.getElementById(correctIndex.toString());
+                        position.style.backgroundColor = "#FF7F7F";
+                        let span = position.getElementsByTagName('span');
+                        span[0].innerHTML = tag;
+                        let fu = ctrl.modals[cacheLevel]['modal-'+aWay+aIndex]['fu'];
+                        ctrl.modals[cacheLevel]['modal-'+aWay+aIndex] = {
+                            'tag' : tag,
+                            'block' : block,
+                            'valid' : valid,
+                            'dirty' : dirty,
+                            'age' : age,
+                            'fu' : fu + 1,
+                            'pos' : ctrl.posInQueue++,
+                        };
+                    }
+                    if (policy == "FIFO") {
+                        let size = ctrl.getIndicesSize();
+                        let numWays = ctrl.getAssociativity();
+                        let firstPos = ctrl.posInQueue; //age will always be >= lfu;
+                        let aIndex = 0;
+                        let aWay = 0;
+                        while (way < numWays) {
+                            for (let i = 0; i < size; i++) {
+                                let aPos = ctrl.modals[cacheLevel]['modal-'+way+i];
+                                if (aPos != null) {
+                                    if (aPos['pos'] < firstPos) {
+                                        firstPos = aPos['pos'];
+                                        aIndex = i;
+                                        aWay = way;
+                                    }
+                                }
+                            }
+                            way++;
+                        }
+                        let correctIndex = (ctrl.getIndicesSize() * parseInt(aWay)) + parseInt(aIndex);
+                        position = document.getElementById(correctIndex.toString());
+                        position.style.backgroundColor = "#FF7F7F";
+                        let span = position.getElementsByTagName('span');
+                        span[0].innerHTML = tag;
+                        let fu = ctrl.modals[cacheLevel]['modal-'+aWay+aIndex]['fu'];
+                        ctrl.modals[cacheLevel]['modal-'+aWay+aIndex] = {
+                            'tag' : tag,
+                            'block' : block,
+                            'valid' : valid,
+                            'dirty' : dirty,
+                            'age' : age,
+                            'fu' : fu + 1,
+                            'pos' : ctrl.posInQueue++,
+                        };
+                    }
+                }
+            }
+        }
+    });
+
+    ctrl.getAssociativity = function(event) {
+        return parseInt(ctrl.cacheInfo.caches[ctrl.index].associativity);
+    };
+
+    ctrl.getIndicesSize = function(event) {
+        let cache = ctrl.cacheInfo.caches[ctrl.index];
+        let C = cache.C;
+        let S = cache.S;
+        let B = ctrl.cacheInfo.B;
+        return Math.pow(2,C-S-B);
+    };
+
+    ctrl.getBlockSize = function(event) {
+        return Math.pow(2,ctrl.cacheInfo.B);
+    };
+
+    let modal;
+    let span;
+    let activeCache;
+    let modalOpen = false;
+
+    ctrl.openModal = function(event, id, info) {
+        if (!modalOpen) {
+            modal = document.getElementById(id);
+            span = document.getElementsByClassName('close')[0];
+            modal.style.display = 'block';
+            activeCache = document.getElementById('activeCacheBanner');
+            activeCache.style.visibility = 'hidden';
+            modalOpen = true;
+        }
+    };
+
+    ctrl.closeModalSpan = function(event) {
+        if (event) {
+            event.stopPropagation();
+            event.preventDefault();
+            modal.style.display = 'none';
+            activeCache.style.visibility = 'visible';
+            modalOpen = false;
+        }
+    };
+
+    window.onclick = function(event) {
+        if (event.target == modal) {
+            modal.style.display = 'none';
+            activeCache.style.visibility = 'visible';
+            modalOpen = false;
+        }
+    };
+}

--- a/src/browser/cacheDetail.html
+++ b/src/browser/cacheDetail.html
@@ -1,268 +1,68 @@
-'use strict';
-
-angular.module('Simulator').component('cacheDetail', {
-    templateUrl: 'src/browser/cacheDetail.html',
-    controller: ['$scope', 'SimDriver', CacheDetailController],
-    bindings: {}
-});
-
-function CacheDetailController($scope, SimDriver) {
-
-    let ctrl = this;
-
-    ctrl.cacheInfo = $scope.$parent.initialCacheInfo;
-
-    ctrl.posInQueue = 0;
-    ctrl.overallAge = 0;
-    ctrl.activeCache = 'L1';
-    ctrl.maq = [];
-    ctrl.index = 0;
-    ctrl.modals = {};
-    ctrl.modals = {
-        'L1' : {},
-        'L2' : {},
-        'L3': {}
-    };
-
-    $scope.$on('updatedNavs', function(event, data, index) {
-        ctrl.activeCache = data.buttonTitle;
-        ctrl.maq = SimDriver.setQueue(SimDriver.getMemAcceses());
-        ctrl.index = index;
-    });
-
-    $scope.$on('cacheInfoUpdated', function(event, data) {
-        ctrl.cacheInfo = data;
-    });
-
-    $scope.$on('updateModals', function (event, data) {
-        console.log('updating modals', data);
-        ctrl.overallAge++;
-        for (let action of data) {
-            console.log(action);
-            let address = action.address
-            let cacheLevel = action.level;
-            let way = action.way;
-            let index = action.index;
-            let tag = action.tag;
-            let block = action.block; //Array of memory addresses associated with given tag
-            let valid = action.valid;
-            let dirty = action.dirty;
-            let age = ctrl.overallAge;
-            let position = document.getElementById(index.toString());
-            if (ctrl.modals[cacheLevel]['modal-'+way+index] == null) {
-                position.style.backgroundColor = "#7FFF00";
-                let span = position.getElementsByTagName('span');
-                span[0].innerHTML = tag;
-                ctrl.modals[cacheLevel]['modal-'+way+index] = {
-                    'tag' : tag,
-                    'block' : block,
-                    'valid' : valid,
-                    'dirty' : dirty,
-                    'age' : age,
-                    'fu' : 0,
-                    'pos' : ctrl.posInQueue++,
-                };
-            } else {
-                if (ctrl.modals[cacheLevel]['modal-'+way+index]['tag'] == tag) {
-                    position.style.backgroundColor = "#6767FF";
-                    let span = position.getElementsByTagName('span');
-                    span[0].innerHTML = tag;
-                    let fu = ctrl.modals[cacheLevel]['modal-'+way+index]['fu'];
-                    ctrl.modals[cacheLevel]['modal-'+way+index] = {
-                        'tag' : tag,
-                        'block' : block,
-                        'valid' : valid,
-                        'dirty' : dirty,
-                        'age' : age,
-                        'fu' : fu + 1,
-                        'pos' : ctrl.posInQueue,
-                    };
-                    return;
-                }
-                let numWays = ctrl.getAssociativity();
-                let checker = true;
-                while (way < (numWays - 1)) {
-                    way++;
-                    if (ctrl.modals[cacheLevel]['modal-'+way+index] == null) {
-                        let correctIndex = (ctrl.getIndicesSize() * parseInt(way)) + parseInt(index);
-                        position = document.getElementById(correctIndex.toString());
-                        position.style.backgroundColor = "#7FFF00";
-                        let span = position.getElementsByTagName('span');
-                        span[0].innerHTML = tag;
-                        ctrl.modals[cacheLevel]['modal-'+way+index] = {
-                            'tag' : tag,
-                            'block' : block,
-                            'valid' : valid,
-                            'dirty' : dirty,
-                            'age' : age,
-                            'fu' : 0,
-                            'pos' : ctrl.posInQueue++,
-                        };
-                        checker = false;
-                        break;
-                    }
-                }
-                if (checker) {
-                    way = action.way;
-                    let policy = ctrl.cacheInfo.policy;
-
-                    if (policy == "LRU") {
-                        let size = ctrl.getIndicesSize();
-                        let numWays = ctrl.getAssociativity();
-                        let youngest = age;
-                        let aIndex = 0;
-                        let aWay = 0;
-                        while (way < numWays) {
-                            for (let i = 0; i < size; i++) {
-                                let aPos = ctrl.modals[cacheLevel]['modal-'+way+i];
-                                if (aPos != null) {
-                                    if (aPos['age'] < youngest) {
-                                        youngest = aPos['age'];
-                                        aIndex = i;
-                                        aWay = way;
-                                    }
-                                }
-                            }
-                            way++;
-                        }
-                        let correctIndex = (ctrl.getIndicesSize() * parseInt(aWay)) + parseInt(aIndex);
-                        position = document.getElementById(correctIndex.toString());
-                        position.style.backgroundColor = "#FF7F7F";
-                        let span = position.getElementsByTagName('span');
-                        span[0].innerHTML = tag;
-                        let fu = ctrl.modals[cacheLevel]['modal-'+aWay+aIndex]['fu'];
-                        ctrl.modals[cacheLevel]['modal-'+aWay+aIndex] = {
-                            'tag' : tag,
-                            'block' : block,
-                            'valid' : valid,
-                            'dirty' : dirty,
-                            'age' : age,
-                            'fu' : fu + 1,
-                            'pos' : ctrl.posInQueue++,
-                        };
-                    }
-                    if (policy == "LFU") {
-                        let size = ctrl.getIndicesSize();
-                        let numWays = ctrl.getAssociativity();
-                        let lfu = age; //age will always be >= lfu;
-                        let aIndex = 0;
-                        let aWay = 0;
-                        while (way < numWays) {
-                            for (let i = 0; i < size; i++) {
-                                let aPos = ctrl.modals[cacheLevel]['modal-'+way+i];
-                                if (aPos != null) {
-                                    if (aPos['fu'] < lfu) {
-                                        lfu = aPos['fu'];
-                                        aIndex = i;
-                                        aWay = way;
-                                    }
-                                }
-                            }
-                            way++;
-                        }
-                        let correctIndex = (ctrl.getIndicesSize() * parseInt(aWay)) + parseInt(aIndex);
-                        position = document.getElementById(correctIndex.toString());
-                        position.style.backgroundColor = "#FF7F7F";
-                        let span = position.getElementsByTagName('span');
-                        span[0].innerHTML = tag;
-                        let fu = ctrl.modals[cacheLevel]['modal-'+aWay+aIndex]['fu'];
-                        ctrl.modals[cacheLevel]['modal-'+aWay+aIndex] = {
-                            'tag' : tag,
-                            'block' : block,
-                            'valid' : valid,
-                            'dirty' : dirty,
-                            'age' : age,
-                            'fu' : fu + 1,
-                            'pos' : ctrl.posInQueue++,
-                        };
-                    }
-                    if (policy == "FIFO") {
-                        let size = ctrl.getIndicesSize();
-                        let numWays = ctrl.getAssociativity();
-                        let firstPos = ctrl.posInQueue; //age will always be >= lfu;
-                        let aIndex = 0;
-                        let aWay = 0;
-                        while (way < numWays) {
-                            for (let i = 0; i < size; i++) {
-                                let aPos = ctrl.modals[cacheLevel]['modal-'+way+i];
-                                if (aPos != null) {
-                                    if (aPos['pos'] < firstPos) {
-                                        firstPos = aPos['pos'];
-                                        aIndex = i;
-                                        aWay = way;
-                                    }
-                                }
-                            }
-                            way++;
-                        }
-                        let correctIndex = (ctrl.getIndicesSize() * parseInt(aWay)) + parseInt(aIndex);
-                        position = document.getElementById(correctIndex.toString());
-                        position.style.backgroundColor = "#FF7F7F";
-                        let span = position.getElementsByTagName('span');
-                        span[0].innerHTML = tag;
-                        let fu = ctrl.modals[cacheLevel]['modal-'+aWay+aIndex]['fu'];
-                        ctrl.modals[cacheLevel]['modal-'+aWay+aIndex] = {
-                            'tag' : tag,
-                            'block' : block,
-                            'valid' : valid,
-                            'dirty' : dirty,
-                            'age' : age,
-                            'fu' : fu + 1,
-                            'pos' : ctrl.posInQueue++,
-                        };
-                    }
-                }
-            }
-        }
-    });
-
-    ctrl.getAssociativity = function(event) {
-        return parseInt(ctrl.cacheInfo.caches[ctrl.index].associativity);
-    };
-
-    ctrl.getIndicesSize = function(event) {
-        let cache = ctrl.cacheInfo.caches[ctrl.index];
-        let C = cache.C;
-        let S = cache.S;
-        let B = ctrl.cacheInfo.B;
-        return Math.pow(2,C-S-B);
-    };
-
-    ctrl.getBlockSize = function(event) {
-        return Math.pow(2,ctrl.cacheInfo.B);
-    };
-
-    let modal;
-    let span;
-    let activeCache;
-    let modalOpen = false;
-
-    ctrl.openModal = function(event, id, info) {
-        if (!modalOpen) {
-            modal = document.getElementById(id);
-            span = document.getElementsByClassName('close')[0];
-            modal.style.display = 'block';
-            activeCache = document.getElementById('activeCacheBanner');
-            activeCache.style.visibility = 'hidden';
-            modalOpen = true;
-        }
-    };
-
-    ctrl.closeModalSpan = function(event) {
-        if (event) {
-            event.stopPropagation();
-            event.preventDefault();
-            modal.style.display = 'none';
-            activeCache.style.visibility = 'visible';
-            modalOpen = false;
-        }
-    };
-
-    window.onclick = function(event) {
-        if (event.target == modal) {
-            modal.style.display = 'none';
-            activeCache.style.visibility = 'visible';
-            modalOpen = false;
-        }
-    };
-}
+<!-- Below is from a demo, need to change content -->
+<head>
+    <link href="src/browser/cacheDetail.css" rel="stylesheet">
+</head>
+<md-toolbar id="activeCacheBanner" class="md-table-toolbar md-default">
+  <div class="md-toolbar-tools">
+    <span>{{$ctrl.activeCache}}</span>
+  </div>
+</md-toolbar>
+<md-table-container>
+  <table id="fillWidth">
+    <tr>
+      <td ng-repeat="x in [].constructor($ctrl.getAssociativity()) track by $index">
+        <table class="tableCollapse" md-table md-row-select multiple ng-model="selected" md-progress="promise">
+          <thead md-head md-order="query.order">
+            <tr md-row>
+              <th class="index" md-column>Index</th>
+              <th class="center" md-column>Tag</th>
+              <th class="validDirty" md-column>Valid</th>
+              <th class="validDirty" md-column>Dirty</th>
+            </tr>
+          </thead>
+          <tbody md-body>
+            <tr md-row ng-repeat="x in [].constructor($ctrl.getIndicesSize()) track by $index">
+              <td class="index" md-cell> {{$index}} </td>
+              <td id="{{$parent.$index * $ctrl.getIndicesSize() + $index}}" md-cell ng-click="$ctrl.openModal($event,'modal-' + $parent.$index + $index, 'modal-' + $parent.$index + $index + -tag)">
+                <span id="{{ 'modal-' + $parent.$index + $index + 'tag'}}"></span>
+                <!-- The Modal -->
+                  <div id="{{ 'modal-' + $parent.$index + $index}}" class="modal">
+                    <!-- Modal content -->
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <span class="close" ng-click="$ctrl.closeModalSpan($event)">&times;</span>
+                        <h2>Block associated with given tag: {{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['tag']}}</h2>
+                      </div>
+                      <div class="modal-body">
+                        <p>
+                        Cache: {{$ctrl.activeCache}} <br>
+                        Way: {{$parent.$index}} <br>
+                        Index: {{$index}} 
+                        </p>
+                        <table id="fillWidthAndHeight">
+                          <thead md-head md-order="query.order">
+                            <tr md-row>
+                              <th class="address" md-column>Address</th>
+                              <th class="center" md-column>Offset</th>
+                            </tr>
+                            <tbody>
+                              <tr md-row ng-repeat="x in [].constructor($ctrl.getBlockSize()) track by $index"> 
+                                <td> 0x{{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$parent.$index + $parent.$index]['block'][$index].toString(16)}} </td>
+                                <td> {{$index.toString(2)}} </td>
+                              </tr>
+                            </tbody>
+                          </thead>
+                        </table>
+                      </div>
+                    </div>
+                  </div>
+              </td>
+              <td class = 'validDirty'>{{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['valid']}}</td>
+              <td class = 'validDirty'>{{$ctrl.modals[$ctrl.activeCache]['modal-' + $parent.$index + $index]['dirty']}}</td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+  </table>
+</md-table-container>

--- a/src/browser/cacheDetail.html
+++ b/src/browser/cacheDetail.html
@@ -3,7 +3,7 @@
     <link href="src/browser/cacheDetail.css" rel="stylesheet">
 </head>
 <md-toolbar id="activeCacheBanner" class="md-table-toolbar md-default">
-  <div class="md-toolbar-tools">
+  <div id="{{$ctrl.activeCache}}" class="md-toolbar-tools">
     <span>{{$ctrl.activeCache}}</span>
   </div>
 </md-toolbar>

--- a/src/browser/cacheDetail.js
+++ b/src/browser/cacheDetail.js
@@ -62,6 +62,9 @@ function CacheDetailController($scope, SimDriver) {
                     'fu' : 0,
                     'pos' : ctrl.posInQueue++,
                 };
+                let title = document.getElementById(ctrl.activeCache);
+                let titleSpan = title.getElementsByTagName('span');
+                titleSpan[0].innerHTML = ctrl.activeCache;
             } else {
                 if (ctrl.modals[cacheLevel]['modal-'+way+index]['tag'] == tag) {
                     position.style.backgroundColor = "#6767FF";
@@ -77,6 +80,9 @@ function CacheDetailController($scope, SimDriver) {
                         'fu' : fu + 1,
                         'pos' : ctrl.posInQueue,
                     };
+                    let title = document.getElementById(ctrl.activeCache);
+                    let titleSpan = title.getElementsByTagName('span');
+                    titleSpan[0].innerHTML = ctrl.activeCache;
                     return;
                 }
                 let numWays = ctrl.getAssociativity();
@@ -99,6 +105,9 @@ function CacheDetailController($scope, SimDriver) {
                             'pos' : ctrl.posInQueue++,
                         };
                         checker = false;
+                        let title = document.getElementById(ctrl.activeCache);
+                        let titleSpan = title.getElementsByTagName('span');
+                        titleSpan[0].innerHTML = ctrl.activeCache;
                         break;
                     }
                 }
@@ -131,6 +140,7 @@ function CacheDetailController($scope, SimDriver) {
                         let span = position.getElementsByTagName('span');
                         span[0].innerHTML = tag;
                         let fu = ctrl.modals[cacheLevel]['modal-'+aWay+aIndex]['fu'];
+                        let prevTag = ctrl.modals[cacheLevel]['modal-'+aWay+aIndex]['tag'];
                         ctrl.modals[cacheLevel]['modal-'+aWay+aIndex] = {
                             'tag' : tag,
                             'block' : block,
@@ -140,6 +150,9 @@ function CacheDetailController($scope, SimDriver) {
                             'fu' : fu + 1,
                             'pos' : ctrl.posInQueue++,
                         };
+                        let title = document.getElementById(ctrl.activeCache);
+                        let titleSpan = title.getElementsByTagName('span');
+                        titleSpan[0].innerHTML = ctrl.activeCache + ", block at index: " + aIndex + ", tag: " + prevTag + " was EVICTED.";
                     }
                     if (policy == "LFU") {
                         let size = ctrl.getIndicesSize();
@@ -166,6 +179,7 @@ function CacheDetailController($scope, SimDriver) {
                         let span = position.getElementsByTagName('span');
                         span[0].innerHTML = tag;
                         let fu = ctrl.modals[cacheLevel]['modal-'+aWay+aIndex]['fu'];
+                        let prevTag = ctrl.modals[cacheLevel]['modal-'+aWay+aIndex]['tag'];
                         ctrl.modals[cacheLevel]['modal-'+aWay+aIndex] = {
                             'tag' : tag,
                             'block' : block,
@@ -175,6 +189,9 @@ function CacheDetailController($scope, SimDriver) {
                             'fu' : fu + 1,
                             'pos' : ctrl.posInQueue++,
                         };
+                        let title = document.getElementById(ctrl.activeCache);
+                        let titleSpan = title.getElementsByTagName('span');
+                        titleSpan[0].innerHTML = ctrl.activeCache + ", block at index: " + aIndex + ", tag: " + prevTag + " was EVICTED.";
                     }
                     if (policy == "FIFO") {
                         let size = ctrl.getIndicesSize();
@@ -201,6 +218,7 @@ function CacheDetailController($scope, SimDriver) {
                         let span = position.getElementsByTagName('span');
                         span[0].innerHTML = tag;
                         let fu = ctrl.modals[cacheLevel]['modal-'+aWay+aIndex]['fu'];
+                        let prevTag = ctrl.modals[cacheLevel]['modal-'+aWay+aIndex]['tag'];
                         ctrl.modals[cacheLevel]['modal-'+aWay+aIndex] = {
                             'tag' : tag,
                             'block' : block,
@@ -210,6 +228,9 @@ function CacheDetailController($scope, SimDriver) {
                             'fu' : fu + 1,
                             'pos' : ctrl.posInQueue++,
                         };
+                        let title = document.getElementById(ctrl.activeCache);
+                        let titleSpan = title.getElementsByTagName('span');
+                        titleSpan[0].innerHTML = ctrl.activeCache + ", block at index: " + aIndex + ", tag: " + prevTag + " was EVICTED.";
                     }
                 }
             }

--- a/src/browser/cacheDetail.js
+++ b/src/browser/cacheDetail.js
@@ -230,6 +230,7 @@ function CacheDetailController($scope, SimDriver) {
                         };
                         let title = document.getElementById(ctrl.activeCache);
                         let titleSpan = title.getElementsByTagName('span');
+                        //displays which tag at what index was evicted
                         titleSpan[0].innerHTML = ctrl.activeCache + ", block at index: " + aIndex + ", tag: " + prevTag + " was EVICTED.";
                     }
                 }

--- a/src/sim/mockSim.js
+++ b/src/sim/mockSim.js
@@ -10,7 +10,10 @@ function initSim(data) {
 
 function mockRunSim(data) {
     initSim(data);
-    mockActions = [[action(cache, '0x00000001', 0, 0, 0)], [action(cache, '0xddccbbaa', 0, 0, 0)]];
+    mockActions = [[action(cache, '0x99baddad', 0, 0, 0)], [action(cache, '0x99090000', 0, 0, 0)], [action(cache, '0x43443493', 0, 0, 0)],
+        [action(cache, '0x44983433', 0, 0, 0)], [action(cache, '0x43bdaaaa', 0, 0, 0)], [action(cache, '0x5520ffff', 0, 0, 0)],
+        [action(cache, '0xffffffff', 0, 0, 0)], [action(cache, '0xdeaddead', 0, 0, 0)], [action(cache, '0x77777777', 0, 0, 0)], 
+        [action(cache, '0x10000000', 0, 0, 0)], [action(cache, '0x00000099', 0, 0, 0)]];
     console.log(mockActions);
 }
 
@@ -48,7 +51,6 @@ function block(initAddress, B) {
 // the star next to the function name declares this function as a generator
 function *nextActionGen() {
     let i = 0;
-
     while (true) {
         yield mockActions[i];
         i = (i + 1) % mockActions.length;


### PR DESCRIPTION
This issue handles the front end coloring of cache blocks in cache details

a green color is shown on a block whose been added to the cache at an index which was previously empty

a blueish color is shown on a block whenever a block at an index and a block coming from the simulator with the same index have the same tag showing a hit.

a red color is shown on a block whenever a block at an index and a block coming from the simulator with the same index have different tags showing a block has been evicted.

Also a label appears on the top stating which block at what index and tag was evicted.

This still uses the mock sim to work and as a result only handles the L1 cache at the moment not all three levels.

mock sim was updated slightly and the mockactions are the same as the one from the test.trace file